### PR TITLE
Add prerelease tag to build before release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ jobs:
           release_name: v${{ env.BUILD_DATE }}
           body: |
             Automated release powered by GitHub Actions.
+          prerelease: true
 
       - name: Upload ISO as Release Asset
         id: upload_asset


### PR DESCRIPTION
# What's new ?

- Added a prerelease tag to github builds to crosscheck before final release